### PR TITLE
Add return type annotation to range() in TS defs

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -27,8 +27,8 @@ export default class AVLTree<Key extends any, Value extends any> {
   minNode(): Node<Key, Value>;
   maxNode(): Node<Key, Value>;
   forEach(callback: ForEachCallback<Key, Value>): AVLTree<Key, Value>;
-  range(minKey:Key, maxKey:Key, visit:TraverseCallback<Key, Value>, context?:any);
-  load(keys: Array<Key>, values?:Array<Value>): AVLTree<Key, Value>;
+  range(minKey: Key, maxKey: Key, visit: TraverseCallback<Key, Value>, context?: any): AVLTree<Key, Value>;
+  load(keys: Array<Key>, values?: Array<Value>): AVLTree<Key, Value>;
   prev(node: Node<Key, Value>): Node<Key, Value>;
   next(node: Node<Key, Value>): Node<Key, Value>;
   isBalanced(): boolean;


### PR DESCRIPTION
Thanks for this great library! In the TypeScript definition, it seems that the range() function is lacking a return type which results in this error in TS strict mode:

```
node_modules/avl/src/index.d.ts:30:3 - error TS7010: 'range', which lacks return-type annotation, implicitly has an 'any' return type.

30   range(minKey:Key, maxKey:Key, visit:TraverseCallback<Key, Value>, context?:any);
     ~~~~~
```

 This change should fix that.