### PR TITLE
Add above/below functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Or use the compiled version 'dist/avl.js'.
 * `tree.insert(key:any, [data:any])` - Insert item
 * `tree.remove(key:any)` - Remove item
 * `tree.find(key):Node|Null` - Return node by its key
+* `tree.above(key):Node|Null` - Returns the node that has the minimum key strictly above the given key, else null
+* `tree.below(key):Node|Null` - Returns the node that has the maximum key strictly below the given key, else null
 * `tree.at(index:Number):Node|Null` - Return node by its index in sorted order of keys
 * `tree.contains(key):Boolean` - Whether a node with the given key is in the tree
 * `tree.forEach(function(node) {...}):Tree` In-order traversal
@@ -75,7 +77,7 @@ Or use the compiled version 'dist/avl.js'.
 
  By default, tree allows duplicate keys. You can disable that by passing `true`
  as a second parameter to the tree constructor. In that case if you would try to
- instert an item with the key, that is already present in the tree, it will not
+ insert an item with the key, that is already present in the tree, it will not
  be inserted.
  However, the default behavior allows for duplicate keys, cause there are cases
  where you cannot predict that the keys would be unique (example: overlapping

--- a/src/index.ts
+++ b/src/index.ts
@@ -432,6 +432,46 @@ export class AVLTree<K = number, V = unknown> {
   }
 
   /**
+   * Returns the node that has the minimum key strictly above the given key, else null
+   */
+  above(key: K) {
+    const compare = this._comparator;
+    let node = this.root;
+    let candidate: AVLNode<K, V> | null = null;
+
+    while (node) {
+      if (compare(node.key, key) > 0) {
+        candidate = node;
+        node = node.left;
+      } else {
+        node = node.right;
+      }
+    }
+
+    return candidate;
+  }
+
+  /**
+   * Returns the node that has the maximum key strictly below the given key, else null
+   */
+  below(key: K) {
+    const compare = this._comparator;
+    let node = this.root;
+    let candidate: AVLNode<K, V> | null = null;
+
+    while (node) {
+      if (compare(node.key, key) < 0) {
+        candidate = node;
+        node = node.right;
+      } else {
+        node = node.left;
+      }
+    }
+
+    return candidate;
+  }
+
+  /**
    * Insert a node into the tree
    */
   insert(key: K, data?: V) {

--- a/tests/above-below.test.ts
+++ b/tests/above-below.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, assert } from "vitest";
+import { Tree } from "../src/";
+import { AVLNode } from "../src/types";
+
+describe("above and below", () => {
+  it("should return the first node strictly greater than the key for above", () => {
+    const tree = new Tree<number>();
+    const keys = [10, 20, 30, 40];
+    keys.forEach((v) => {
+      for (let i = 0; i < 4; i++) tree.insert(v);
+    });
+
+    const node = tree.above(20)!;
+
+    const collected: number[] = [];
+    let n: AVLNode<number, unknown> | null = node;
+    while (n) {
+      collected.push(n.key);
+      n = tree.next(n);
+    }
+    assert.deepEqual(collected, [30, 30, 30, 30, 40, 40, 40, 40]);
+  });
+
+  it("should return the first node strictly less than the key for below", () => {
+    const tree = new Tree<number>();
+    const keys = [10, 20, 30, 40];
+    keys.forEach((v) => {
+      for (let i = 0; i < 4; i++) tree.insert(v);
+    });
+
+    const node = tree.below(30)!;
+
+    const collected: number[] = [];
+    let n: AVLNode<number, unknown> | null = node;
+    while (n) {
+      collected.push(n.key);
+      n = tree.prev(n);
+    }
+    assert.deepEqual(collected, [20, 20, 20, 20, 10, 10, 10, 10]);
+  });
+
+  it("should return null if no node is above", () => {
+    const tree = new Tree<number>();
+    [10, 20, 30].forEach((v) => {
+      for (let i = 0; i < 4; i++) tree.insert(v);
+    });
+
+    assert.isNull(tree.above(30));
+    assert.isNull(tree.above(40));
+  });
+
+  it("should return null if no node is below", () => {
+    const tree = new Tree<number>();
+    [10, 20, 30].forEach((v) => {
+      for (let i = 0; i < 4; i++) tree.insert(v);
+    });
+
+    assert.isNull(tree.below(10));
+    assert.isNull(tree.below(5));
+  });
+
+  it("should work for keys not in tree", () => {
+    const tree = new Tree<number>();
+    const keys = [10, 20, 30, 40];
+    keys.forEach((v) => {
+      for (let i = 0; i < 4; i++) tree.insert(v);
+    });
+
+    let node: AVLNode<number, unknown> | null = tree.above(15)!;
+    assert.equal(node.key, 20);
+
+    node = tree.below(25)!;
+    assert.equal(node.key, 20);
+
+    node = tree.above(5)!;
+    assert.equal(node.key, 10);
+
+    node = tree.below(5);
+    assert.isNull(node);
+
+    node = tree.above(50);
+    assert.isNull(node);
+
+    node = tree.below(50)!;
+    assert.equal(node.key, 40);
+  });
+});


### PR DESCRIPTION
The purpose of this PR is to facilitate search filtering in ascending/descending order of the keys. If i want to find all the nodes having keys in the range [x, y] in ascending order, then i need to find the node with key below x as the start point. Similarly, if i want to find them in descending order, i need to find the node with key above y as the starting point. Also, I should be able to do it without knowing if x or y are keys in the tree.